### PR TITLE
Add fields to Message to support the ticker channel

### DIFF
--- a/message.go
+++ b/message.go
@@ -24,4 +24,7 @@ type Message struct {
 	Bids          [][]string `json:"bids,omitempty"`
 	Asks          [][]string `json:"asks,omitempty"`
 	Changes       [][]string `json:"changes,omitempty"`
+	LastSize      float64    `json:"last_size,string"`
+	BestBid       float64    `json:"best_bid,string"`
+	BestAsk       float64    `json:"best_ask,string"`
 }


### PR DESCRIPTION
This change adds three fields to the Message struct to support decoding messages in the websocket [ticker channel](https://docs.gdax.com/#the-code-classprettyprinttickercode-channel).