### PR TITLE
Add CancelAll API call

### DIFF
--- a/order.go
+++ b/order.go
@@ -29,6 +29,10 @@ type Order struct {
 	ExecutedValue float64 `json:"executed_value,string,omitempty"`
 }
 
+type CancelAllOrdersParams struct {
+	ProductID string `json:"product_id,string,omitempty"`
+}
+
 type ListOrdersParams struct {
 	Status     string
 	Pagination PaginationParams
@@ -52,8 +56,11 @@ func (c *Client) CancelOrder(id string) error {
 	return err
 }
 
-func (c *Client) CancelAll() ([]string, error) {
+func (c *Client) CancelAllOrders(p ...CancelAllOrdersParams) ([]string, error) {
 	var orderIDs []string
+	if len(p) == 0 {
+		p = nil
+	}
 	_, err := c.Request("DELETE", "/orders", nil, &orderIDs)
 	return orderIDs, err
 }

--- a/order.go
+++ b/order.go
@@ -52,6 +52,12 @@ func (c *Client) CancelOrder(id string) error {
 	return err
 }
 
+func (c *Client) CancelAll() ([]string, error) {
+	var orderIDs []string
+	_, err := c.Request("DELETE", "/orders", nil, &orderIDs)
+	return orderIDs, err
+}
+
 func (c *Client) GetOrder(id string) (Order, error) {
 	var savedOrder Order
 

--- a/order_test.go
+++ b/order_test.go
@@ -133,18 +133,37 @@ func TestListOrders(t *testing.T) {
 	}
 }
 
-func TestCancelAll(t *testing.T) {
+func TestCancelAllOrders(t *testing.T) {
 	client := NewTestClient()
 
-	if cursor := client.ListOrders(); !cursor.HasMore {
-		t.Error("There are no orders to cancel")
-	}
-
-	if _, err := client.CancelAll(); err != nil {
+	// Clear any orders that may have been left over from other tests
+	if _, err := client.CancelAllOrders(); err != nil {
 		t.Error(err)
 	}
 
-	if cursor := client.ListOrders(); cursor.HasMore {
-		t.Error("Orders still exist after cancelling all")
+	for _, pair := range []string{"BTC-USD", "ETH-USD", "LTC-USD"} {
+		order := Order{Price: 1.00, Size: 1.00, Side: "buy", ProductId: pair}
+
+		if _, err := client.CreateOrder(&order); err != nil {
+			t.Error(err)
+		}
+	}
+
+	orderIDs, err := client.CancelAllOrders(CancelAllOrdersParams{ProductID: "LTC-USD"})
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(orderIDs) != 1 {
+		t.Error("Did not cancel single order")
+	}
+
+	orderIDs, err = client.CancelAllOrders()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(orderIDs) != 2 {
+		t.Error("Did not cancel remaining orders")
 	}
 }

--- a/order_test.go
+++ b/order_test.go
@@ -132,3 +132,19 @@ func TestListOrders(t *testing.T) {
 		}
 	}
 }
+
+func TestCancelAll(t *testing.T) {
+	client := NewTestClient()
+
+	if cursor := client.ListOrders(); !cursor.HasMore {
+		t.Error("There are no orders to cancel")
+	}
+
+	if _, err := client.CancelAll(); err != nil {
+		t.Error(err)
+	}
+
+	if cursor := client.ListOrders(); cursor.HasMore {
+		t.Error("Orders still exist after cancelling all")
+	}
+}


### PR DESCRIPTION
This adds the ability to cancel all open orders in a single call.

The public sandbox seems to be down at the moment, so even though I have written a test, I can't run it. 