### PR TITLE
Added the ability to sign a messages sent over the websocket.

### DIFF
--- a/client.go
+++ b/client.go
@@ -2,9 +2,6 @@ package gdax
 
 import (
 	"bytes"
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -118,25 +115,10 @@ func (c *Client) Headers(method, url, timestamp, data string) (map[string]string
 		data,
 	)
 
-	sig, err := c.generateSig(message, c.Secret)
+	sig, err := generateSig(message, c.Secret)
 	if err != nil {
 		return nil, err
 	}
 	h["CB-ACCESS-SIGN"] = sig
 	return h, nil
-}
-
-func (c *Client) generateSig(message, secret string) (string, error) {
-	key, err := base64.StdEncoding.DecodeString(secret)
-	if err != nil {
-		return "", err
-	}
-
-	signature := hmac.New(sha256.New, key)
-	_, err = signature.Write([]byte(message))
-	if err != nil {
-		return "", err
-	}
-
-	return base64.StdEncoding.EncodeToString(signature.Sum(nil)), nil
 }

--- a/message.go
+++ b/message.go
@@ -29,9 +29,19 @@ type Message struct {
 	BestBid       float64          `json:"best_bid,string"`
 	BestAsk       float64          `json:"best_ask,string"`
 	Channels      []MessageChannel `json:"channels"`
+	UserId        string           `json:"user_id"`
+	ProfileId     string           `json:"profile_id"`
 }
 
 type MessageChannel struct {
 	Name       string   `json:"name"`
 	ProductIds []string `json:"product_ids"`
+}
+
+type SignedMessage struct {
+	Message
+	Key        string `json:"key"`
+	Passphrase string `json:"passphrase"`
+	Timestamp  string `json:"timestamp"`
+	Signature  string `json:"signature"`
 }

--- a/signing.go
+++ b/signing.go
@@ -1,0 +1,41 @@
+package gdax
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+func generateSig(message, secret string) (string, error) {
+	key, err := base64.StdEncoding.DecodeString(secret)
+	if err != nil {
+		return "", err
+	}
+
+	signature := hmac.New(sha256.New, key)
+	_, err = signature.Write([]byte(message))
+	if err != nil {
+		return "", err
+	}
+
+	return base64.StdEncoding.EncodeToString(signature.Sum(nil)), nil
+}
+
+func (m Message) Sign(secret, key, passphrase string) (SignedMessage, error) {
+
+	method := "GET"
+	url := "/users/self/verify"
+	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+	sig, err := generateSig(fmt.Sprintf("%s%s%s", timestamp, method, url), secret)
+
+	return SignedMessage{
+		Message:    m,
+		Key:        key,
+		Passphrase: passphrase,
+		Timestamp:  strconv.FormatInt(time.Now().Unix(), 10),
+		Signature:  sig,
+	}, err
+}


### PR DESCRIPTION
Added the ability to sign a message sent over the websocket e.g subscribe messages 

https://docs.gdax.com/#subscribe

Example: 
```
subscribe := gdax.Message{
	Type: "subscribe",
	Channels: []gdax.MessageChannel{
		gdax.MessageChannel{
			Name: "ticker",
			ProductIds: []string{
				"BTC-USD",
			},
		},
		gdax.MessageChannel{
			Name: "user",
			ProductIds: []string{
				"BTC-USD",
			},
		},
	},
}

signed, err := subscribe.Sign(secret, key, passphrase)
if err != nil {
    println(err.Error())
}

if err := wsConn.WriteJSON(signed); err != nil {
   println(err.Error())
}

```




