### PR TITLE
Rate limit HTTP requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,16 @@
 .env
+
+# Binaries for programs and plugins
+*.exe
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
+.glide/

--- a/product_test.go
+++ b/product_test.go
@@ -54,7 +54,7 @@ func TestListTrades(t *testing.T) {
 	cursor := client.ListTrades("BTC-USD")
 
 	for cursor.HasMore {
-		if err := cursor.NextPage(&trades); err != nil {
+		if err := cursor.PrevPage(&trades); err != nil {
 			t.Error(err)
 		}
 

--- a/rate_limits.go
+++ b/rate_limits.go
@@ -1,0 +1,61 @@
+package gdax
+
+import (
+	"strings"
+
+	"golang.org/x/time/rate"
+)
+
+// https://docs.gdax.com/#rate-limits
+
+type rateLimit struct {
+	rate   rate.Limit
+	bursts int
+}
+
+var publicRateLimit = &rateLimit{
+	rate:   3,
+	bursts: 6,
+}
+
+var privateRateLimit = &rateLimit{
+	rate:   5,
+	bursts: 10,
+}
+
+// NewRateLimiter Create a private or public rate limiter
+func NewRateLimiter(isPrivate bool) *rate.Limiter {
+	if isPrivate {
+		return rate.NewLimiter(privateRateLimit.rate, privateRateLimit.bursts)
+	}
+
+	return rate.NewLimiter(publicRateLimit.rate, publicRateLimit.bursts)
+}
+
+// https://docs.gdax.com/#market-data
+var publicEndpoints = map[string]bool{
+	"/products":   true,
+	"/currencies": true,
+	"/time":       true,
+}
+
+// IsPublicEndpoint determines if requestURL is a public endpoint. See https://docs.gdax.com/#market-data.
+//
+// requestURL should be the path not the entire url, e.g.,
+// correct: /time
+// incorrect: https://api-public.sandbox.gdax.com/time
+func IsPublicEndpoint(requestURL string) bool {
+	_, ok := publicEndpoints[requestURL]
+	if ok {
+		return true
+	}
+
+	for url := range publicEndpoints {
+		public := strings.HasPrefix(requestURL, url)
+		if public {
+			return true
+		}
+	}
+
+	return false
+}

--- a/rate_limits_test.go
+++ b/rate_limits_test.go
@@ -1,0 +1,103 @@
+package gdax
+
+import (
+	"errors"
+	"testing"
+)
+
+var (
+	errNotPublicEndpoint  = errors.New("Expecting url to be a public endpoint")
+	errNotPrivateEndpoint = errors.New("Expecting url to be a private endpoint")
+)
+
+func TestIsPublicEndpoint_PublicEndpoints(t *testing.T) {
+	t.Parallel()
+
+	urls := []string{
+		"/products",
+		"/products/BTC-EUR/book",
+		"/products/BTC-EUR/book?level=1",
+		"/products/BTC-EUR/book?level=2",
+		"/products/BTC-EUR/book?level=3",
+		"/products/BTC-USD/book",
+		"/products/BTC-USD/book?level=1",
+		"/products/BTC-USD/book?level=2",
+		"/products/BTC-USD/book?level=3",
+		"/products/BTC-EUR/ticker",
+		"/products/BTC-USD/ticker",
+		"/products/BTC-EUR/trades",
+		"/products/BTC-USD/trades",
+		"/products/BTC-EUR/candles",
+		"/products/BTC-USD/candles",
+		"/products/BTC-EUR/stats",
+		"/products/BTC-USD/stats",
+		"/currencies",
+		"/currencies/level1",
+		"/currencies/level2",
+		"/currencies/level2/level3",
+		"/time",
+		"/time/level1",
+		"/time/level2",
+		"/time/level2/level3",
+	}
+
+	for _, url := range urls {
+		private := !IsPublicEndpoint(url)
+		if private {
+			t.Error(errNotPublicEndpoint, url)
+		}
+	}
+}
+
+func TestIsPublicEndpoint_PrivateEndpoints(t *testing.T) {
+	t.Parallel()
+
+	urls := []string{
+		"/accounts",
+		"/accounts/9ae6d8dd-ee13-44db-b432-8f8e5912e600",
+		"/accounts/39dbeec4-f26d-457a-8d70-2828a1b9ba70",
+		"/accounts/d866927a-31a6-445b-b27b-60e6bcbedc24",
+		"/accounts/2d833846-82b4-4e11-91b3-94db2f15bb01",
+		"/accounts/9ae6d8dd-ee13-44db-b432-8f8e5912e600/ledger",
+		"/accounts/39dbeec4-f26d-457a-8d70-2828a1b9ba70/ledger",
+		"/accounts/39dbeec4-f26d-457a-8d70-2828a1b9ba70/ledger?after=89782",
+		"/accounts/d866927a-31a6-445b-b27b-60e6bcbedc24/ledger",
+		"/accounts/d866927a-31a6-445b-b27b-60e6bcbedc24/ledger?after=37947807",
+		"/accounts/d866927a-31a6-445b-b27b-60e6bcbedc24/ledger?after=87734",
+		"/accounts/d866927a-31a6-445b-b27b-60e6bcbedc24/ledger?after=77609",
+		"/accounts/d866927a-31a6-445b-b27b-60e6bcbedc24/ledger?after=67084",
+		"/accounts/2d833846-82b4-4e11-91b3-94db2f15bb01/ledger",
+		"/accounts/2d833846-82b4-4e11-91b3-94db2f15bb01/ledger?after=37959337",
+		"/accounts/2d833846-82b4-4e11-91b3-94db2f15bb01/ledger?after=89672",
+		"/accounts/2d833846-82b4-4e11-91b3-94db2f15bb01/ledger?after=86982",
+		"/accounts/2d833846-82b4-4e11-91b3-94db2f15bb01/ledger?after=67561",
+		"/accounts/2d833846-82b4-4e11-91b3-94db2f15bb01/ledger?after=67199",
+		"/accounts/9ae6d8dd-ee13-44db-b432-8f8e5912e600/holds",
+		"/accounts/39dbeec4-f26d-457a-8d70-2828a1b9ba70/holds",
+		"/accounts/d866927a-31a6-445b-b27b-60e6bcbedc24/holds",
+		"/accounts/2d833846-82b4-4e11-91b3-94db2f15bb01/holds",
+		"/fills",
+		"/fills?after=1651566",
+		"/fills?after=11564",
+		"/fills?after=8462",
+		"/fills?after=431",
+		"/fills?product_id=BTC-USD",
+		"/fills?after=1651566&product_id=BTC-USD",
+		"/fills?after=10529&product_id=BTC-USD",
+		"/fills?after=8415&product_id=BTC-USD",
+		"/orders",
+		"/orders/6a81abeb-821f-49f2-9f33-a3bdebca1087",
+		"/orders/fb58ea7a-5a4c-4d48-ab73-59cd2e788820",
+		"/orders/7c2bf4b4-ff45-4999-b8eb-25a9a09ea282",
+		"/orders/7c2bf4b4-ff45-4999-b8eb-25a9a09ea282",
+		"/orders?product_id=LTC-EUR&status=open",
+		"/orders?product_id=BTC-USD",
+	}
+
+	for _, url := range urls {
+		public := IsPublicEndpoint(url)
+		if public {
+			t.Error(errNotPrivateEndpoint, url)
+		}
+	}
+}

--- a/test_helper.go
+++ b/test_helper.go
@@ -3,26 +3,16 @@ package gdax
 import (
 	"errors"
 	"fmt"
-	"net/http"
 	"os"
 	"reflect"
-	"time"
 )
 
 func NewTestClient() *Client {
 	secret := os.Getenv("TEST_COINBASE_SECRET")
 	key := os.Getenv("TEST_COINBASE_KEY")
 	passphrase := os.Getenv("TEST_COINBASE_PASSPHRASE")
-
-	return &Client{
-		BaseURL:    "https://api-public.sandbox.gdax.com",
-		Secret:     secret,
-		Key:        key,
-		Passphrase: passphrase,
-		HttpClient: &http.Client{
-			Timeout: 15 * time.Second,
-		},
-	}
+	isSandbox := true
+	return NewClient(secret, key, passphrase, isSandbox)
 }
 
 func StructHasZeroValues(i interface{}) bool {


### PR DESCRIPTION
* Define a public and private rate limiter.
* Get a different rate limiter based on whether is a public or private endpoint.
* Add `IsPublicEndpoint`--that could be improved upon as I've hardcoded
the list of endpoints---which determines if `requestURL` is public or not.
* Expose `IsSandbox` field in `Client`.

Tests:
* Add tests for `rate_limits` `IsPublicEndpoint` function.
* `TestListTrades`: call `PrevPage` instead of `nextPage` otherwise
we get a never ending stream of trades.
* `NewTestClient`: call `NewClient` with sandbox set to true.