### PR TITLE
Fixed nil dereference in core client request function

### DIFF
--- a/client.go
+++ b/client.go
@@ -42,7 +42,9 @@ func (c *Client) Request(method string, url string,
 		time.Sleep(retryDuration)
 
 		res, err = c.request(method, url, params, result)
-		if res.StatusCode == 429 {
+		if res == nil {
+			continue
+		} else if res.StatusCode == 429 {
 			continue
 		} else {
 			break


### PR DESCRIPTION
There is a nil dereference I've encountered after my code has been running for very long periods of time (> 24 hours). Pasted the panic dump I get below. Ultimately traced it back to that line checking the status code, and the only dereference happening in that line is on `res`, so I treated that same as a 429.

PS - I used two separate clauses for the purposes of clarity, as I thought short-circuiting might make the point less obvious. But short-circuiting is certainly the more concise way to go :)